### PR TITLE
Update repository URLs in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/glueful/vscode-extension.git"
+    "url": "https://github.com/glueful/vs-code-extension.git"
   },
   "homepage": "https://glueful.com",
   "bugs": {
-    "url": "https://github.com/glueful/vscode-extension/issues"
+    "url": "https://github.com/glueful/vs-code-extension/issues"
   },
   "activationEvents": [
     "onLanguage:php"


### PR DESCRIPTION
Changed the repository and bugs URLs to use 'vs-code-extension' instead of 'vscode-extension' to reflect the correct repository path.